### PR TITLE
[#53] fixed null value cast

### DIFF
--- a/jsontableschema/types.py
+++ b/jsontableschema/types.py
@@ -39,6 +39,7 @@ class JTSType(PatternConstraintMixin, EnumConstraintMixin,
     py = type(None)
     name = ''
     formats = ('default',)
+    null_values = list(utilities.NULL_VALUES)
 
     def __init__(self, field=None, **kwargs):
         """Setup some variables for easy access. `field` is the field
@@ -73,8 +74,8 @@ class JTSType(PatternConstraintMixin, EnumConstraintMixin,
     def cast(self, value, skip_constraints=False):
         """Return boolean if `value` can be cast as type `self.py`."""
 
-        # Return None/raise constraint error if value is NULL_VALUE
-        if value in ([None] + utilities.NULL_VALUES):
+        # Return None/raise constraint error if value is null_value
+        if value in ([None] + self.null_values):
             if not skip_constraints:
                 # Now default value for required is False
                 required = self._get_constraint_value('required') or False
@@ -145,6 +146,11 @@ class StringType(LengthConstraintMixin, JTSType):
     name = 'string'
     formats = ('default', 'email', 'uri', 'binary', 'uuid')
     email_pattern = re.compile(r'[^@]+@[^@]+\.[^@]+')
+
+    # String has a special case null values
+    # without an empty string ('')
+    null_values = list(JTSType.null_values)
+    null_values.remove('')
 
     def cast_email(self, value):
         if not self._type_check(value):
@@ -249,7 +255,6 @@ class NullType(JTSType):
 
     py = type(None)
     name = 'null'
-    null_values = utilities.NULL_VALUES
 
     def cast_default(self, value):
         if isinstance(value, self.py):

--- a/jsontableschema/types.py
+++ b/jsontableschema/types.py
@@ -73,16 +73,16 @@ class JTSType(PatternConstraintMixin, EnumConstraintMixin,
     def cast(self, value, skip_constraints=False):
         """Return boolean if `value` can be cast as type `self.py`."""
 
-        # We check on `constraints.required` before we cast
-        if not skip_constraints:
-            required = self._get_constraint_value('required')
-            if required is not None:
-                if not required and (value in (None, utilities.NULL_VALUES)):
-                    return None
-                elif required and value in (None, ''):
-                    raise exceptions.ConstraintError(
-                        msg="The field '{0}' requires a value".format(
-                            self.field_name))
+        # Return None/raise constraint error if value is NULL_VALUE
+        if value in ([None] + utilities.NULL_VALUES):
+            if not skip_constraints:
+                # Now default value for required is False
+                required = self._get_constraint_value('required') or False
+                if required:
+                    message = "The field '{0}' requires a value"
+                    message = message.format(self.field_name)
+                    raise exceptions.ConstraintError(message)
+            return None
 
         # We can check against other pre-cast constraints here too.
         if not skip_constraints:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -45,8 +45,7 @@ class TestStringTypeConstraints_Required(ConstraintsBase):
         field = self._make_default_field(type='string')
         _type = types.StringType(field)
 
-        # Required is false so cast null value to None
-        self.assertEqual(_type.cast(value), None)
+        self.assertEqual(_type.cast(value), '')
 
     def test_constraints_required_true_with_value(self):
         '''Required True with a value'''
@@ -58,15 +57,13 @@ class TestStringTypeConstraints_Required(ConstraintsBase):
         self.assertEqual(_type.cast(value), value)
 
     def test_constraints_required_true_with_no_value(self):
-        '''Required True with no value (empty string) raises an exception.'''
+        '''Required True with no value (empty string) returns empty string.'''
         value = ''
         field = self._make_default_field(type='string',
                                          constraints={'required': True})
         _type = types.StringType(field)
 
-        with pytest.raises(exceptions.ConstraintError) as e:
-            _type.cast(value)
-        self.assertEqual(e.value.msg, "The field 'Name' requires a value")
+        assert _type.cast(value) == value
 
     def test_constraints_required_false_with_value(self):
         '''Required False with a value'''
@@ -84,8 +81,7 @@ class TestStringTypeConstraints_Required(ConstraintsBase):
                                          constraints={'required': False})
         _type = types.StringType(field)
 
-        # Required is false so cast null value to None
-        self.assertEqual(_type.cast(value), None)
+        self.assertEqual(_type.cast(value), '')
 
 
 class TestStringTypeConstraints_MinLength(ConstraintsBase):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -45,7 +45,8 @@ class TestStringTypeConstraints_Required(ConstraintsBase):
         field = self._make_default_field(type='string')
         _type = types.StringType(field)
 
-        self.assertEqual(_type.cast(value), '')
+        # Required is false so cast null value to None
+        self.assertEqual(_type.cast(value), None)
 
     def test_constraints_required_true_with_value(self):
         '''Required True with a value'''
@@ -83,7 +84,8 @@ class TestStringTypeConstraints_Required(ConstraintsBase):
                                          constraints={'required': False})
         _type = types.StringType(field)
 
-        self.assertEqual(_type.cast(value), value)
+        # Required is false so cast null value to None
+        self.assertEqual(_type.cast(value), None)
 
 
 class TestStringTypeConstraints_MinLength(ConstraintsBase):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -184,6 +184,11 @@ class TestData(base.BaseTestCase):
         self.assertEqual(['string', Decimal(10.0), 1, 'string', 'string'],
                          converted_row)
 
+    def test_convert_row_null_values(self):
+        m = model.SchemaModel(self.schema)
+        converted_row = list(m.convert_row('string', '', '-', 'string', 'null'))
+        assert ['string', None, None, 'string', None] == converted_row
+
     def test_convert_row_too_few_items(self):
         m = model.SchemaModel(self.schema)
         self.assertRaises(exceptions.ConversionError, list,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -683,7 +683,6 @@ class TestNullValues(base.BaseTestCase):
         for name, value in self.none_string_types.items():
             self.field['type'] = name
             _type = value(self.field)
-            print(name)
             self.assertRaises(error, _type.cast, 'null')
             self.assertRaises(error, _type.cast, 'none')
             self.assertRaises(error, _type.cast, 'nil')


### PR DESCRIPTION
See - https://github.com/frictionlessdata/jsontableschema-py/issues/53

So after this PR:

```
from jsontableschema.model import SchemaModel

schema = {
    "fields": [
        {
            "name": "value",
            "type": "integer",
        }
    ]
}

model = SchemaModel(schema)
print(model.cast('value', '3'))
# 3
print(model.cast('value', '-'))
# None
print(model.cast('value', ''))
# None
```

I've discovered that other functionality like `convert_row()` etc is based on `cast` so this should fix
other null value problems.