### PR TITLE
Reverted added Table.name

### DIFF
--- a/jsontableschema/table.py
+++ b/jsontableschema/table.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import os
-import six
 from tabulator import Stream
 from functools import partial
 from importlib import import_module
@@ -29,7 +27,7 @@ class Table(object):
 
     # Public
 
-    def __init__(self, source, schema=None, name=None, post_cast=None,
+    def __init__(self, source, schema=None, post_cast=None,
                  backend=None, **options):
 
         # Defaults
@@ -40,13 +38,6 @@ class Table(object):
         self.__schema = None
         if isinstance(schema, (compat.str, dict)):
             self.__schema = Schema(schema)
-
-        # Name
-        self.__name = name
-        if name is None:
-            self.__name = 'table'
-            if isinstance(source, six.string_types):
-                self.__name = os.path.splitext(source.rsplit('/')[-1])[0]
 
         # Tabulator
         if backend is None:
@@ -78,12 +69,6 @@ class Table(object):
         """
         self.__ensure_schema()
         return self.__schema
-
-    @property
-    def name(self):
-        """str: table name
-        """
-        return self.__name
 
     def iter(self, keyed=False, extended=False):
         """Yields table rows.

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -42,12 +42,6 @@ def test_schema_infer_storage(import_module):
     assert Table('table', backend='storage').schema.descriptor == SCHEMA_MIN
 
 
-def test_name():
-    assert Table('data/data_infer.csv', name='name').name == 'name'
-    assert Table('data/data_infer.csv').name == 'data_infer'
-    assert Table([['a', 'b'], [1, 2]]).name == 'table'
-
-
 def test_iter():
     table = Table(DATA_MIN, schema=SCHEMA_MIN)
     expect = [['one', 1], ['two', 2]]


### PR DESCRIPTION
# Overview

There was a try to encapsulate all information needed by `goodtables` in `Table` class but it's just not enough for goodtables (like to have only name of table). So reverting because as stand-alone thing it's not natural for JTS.