### PR TITLE
Fixed Field.test_value behavior

### DIFF
--- a/jsontableschema/field.py
+++ b/jsontableschema/field.py
@@ -105,22 +105,12 @@ class Field(object):
                 return False
 
         # Granular test
-        else:
-
-            # Not supported constraint
-            if constraint not in self.__type.supported_constraints+['unique']:
-                message = 'Field type "%s" does not support "%s" constraint'
-                message = message % (self.type, constraint)
-                raise exceptions.ConstraintNotSupported(message)
-
-            # Cast value if needed
+        if constraint in self.__type.supported_constraints + ['unique']:
             if constraint not in ['required', 'pattern']:
                 try:
                     value = self.__type.cast(value, skip_constraints=True)
                 except exceptions.InvalidCastError:
                     return False
-
-            # Validate value
             validator = getattr(self, '_Field__validate_%s' % constraint)
             try:
                 validator(value)

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -76,8 +76,7 @@ def test_test_value_skip_constraints():
 
 
 def test_test_value_not_supported_constraint():
-    with pytest.raises(exceptions.ConstraintNotSupported):
-        assert Field(DESCRIPTOR_MIN).test_value('', constraint='bad')
+    assert Field(DESCRIPTOR_MIN).test_value('', constraint='bad') == True
 
 
 # Tests [constraints]


### PR DESCRIPTION
# Overview

`Field.test_value(value, constraint=)` should return `True` for non-supported by type constraints instead of raising an exception. It means there is no such a constraint so value is valid. Also this behavior is really desired by `goodtables`. 