### PR TITLE
Fix/number caster succeeds when group char and decimal char are in wrong order

### DIFF
--- a/jsontableschema/types/number.py
+++ b/jsontableschema/types/number.py
@@ -43,8 +43,15 @@ class NumberType(base.JTSType):
             group_char = self.field.get('groupChar', ',')
             decimal_char = self.field.get('decimalChar', '.')
             percent_char = '%‰‱％﹪٪'
+
+            if decimal_char in value:
+                if value.find(decimal_char) < value.find(group_char):
+                    message = 'decimalChar cannot precede groupChar'
+                    raise exceptions.InvalidCastError(message)
+
             value = value.replace(group_char, '').replace(decimal_char, '.')
             value = re.sub('['+percent_char+']', '', value)
+
         return value
 
     def cast_default(self, value, fmt=None):
@@ -72,11 +79,10 @@ class NumberType(base.JTSType):
         if isinstance(value, (int, float)):
             return self.python_type(value)
 
-        value = self.__preprocess_value(value)
-
         try:
             pattern = '[{0}]'.format(self.currencies)
-            value = re.sub(pattern, '', value)
+            value = re.sub(pattern, '', value).strip()
+            value = self.__preprocess_value(value)
             return self.python_type(value)
         except (ValueError, TypeError, decimal.InvalidOperation):
             raise exceptions.InvalidCurrency(

--- a/jsontableschema/types/number.py
+++ b/jsontableschema/types/number.py
@@ -69,8 +69,6 @@ class NumberType(base.JTSType):
         except (ValueError, TypeError, decimal.InvalidOperation) as e:
             raise_with_traceback(exceptions.InvalidCastError(e))
 
-        raise exceptions.InvalidCastError('Could not cast value')
-
     def cast_currency(self, value, fmt=None):
 
         if isinstance(value, self.python_type):
@@ -87,5 +85,3 @@ class NumberType(base.JTSType):
         except (ValueError, TypeError, decimal.InvalidOperation):
             raise exceptions.InvalidCurrency(
                 '{0} is not a valid currency'.format(value))
-
-        raise exceptions.InvalidCastError('Could not cast value')

--- a/jsontableschema/types/number.py
+++ b/jsontableschema/types/number.py
@@ -77,10 +77,11 @@ class NumberType(base.JTSType):
         if isinstance(value, (int, float)):
             return self.python_type(value)
 
+        pattern = '[{0}]'.format(self.currencies)
+        value = re.sub(pattern, '', value).strip()
+        value = self.__preprocess_value(value)
+
         try:
-            pattern = '[{0}]'.format(self.currencies)
-            value = re.sub(pattern, '', value).strip()
-            value = self.__preprocess_value(value)
             return self.python_type(value)
         except (ValueError, TypeError, decimal.InvalidOperation):
             raise exceptions.InvalidCurrency(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import pytest
 from datetime import datetime, date, time
 from decimal import Decimal
 from jsontableschema import types, exceptions
@@ -160,6 +159,13 @@ class TestNumber(base.BaseTestCase):
         ]:
             self.assertTrue(_type.cast(value))
 
+    def test_decimal_char_and_group_char_in_invalid_positions(self):
+        self.field['decimalChar'] = '.'
+        self.field['groupChar'] = ','
+        _type = types.NumberType(self.field)
+        self.assertRaises(exceptions.InvalidCastError,
+                          _type.cast, '1.234.567,89')
+
     def test_number_type_with_currency_format_true(self):
         self.field['format'] = 'currency'
         _type = types.NumberType(self.field)
@@ -182,7 +188,6 @@ class TestNumber(base.BaseTestCase):
             '  10 000,00 £',
         ]:
             self.assertTrue(_type.cast(value))
-
 
     def test_number_type_with_currency_format_false(self):
         value1 = '10,000a.00'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import pytest
 from datetime import datetime, date, time
 from decimal import Decimal
 from jsontableschema import types, exceptions


### PR DESCRIPTION
@roll @akariv 

This PR tries to fix the following inconsistent behaviour:
```
from jsontableschema.types import NumberType
field = {'name': 'foo', 'type': 'number', 'groupChar': ',', 'decimalChar': '.'}
NumberType(field).cast('1.234,56')
Decimal('1.23456')
```

I also removed some unreachable code.