### PR TITLE
Add support for missingValues

### DIFF
--- a/jsontableschema/field.py
+++ b/jsontableschema/field.py
@@ -129,7 +129,7 @@ class Field(object):
         """Validate value against required constraint.
         """
         missing_values = self.descriptor.get('missingValues', [])
-        null_values = self.__type.null_values + missing_values + ['', None]
+        null_values = self.__type.null_values + missing_values
         null_values = map(helpers.normalize_value, null_values)
         if self.required and (helpers.normalize_value(value) in null_values):
             message = 'The field "%s" requires a value' % self.name

--- a/jsontableschema/field.py
+++ b/jsontableschema/field.py
@@ -9,6 +9,7 @@ import six
 from copy import deepcopy
 from functools import partial
 from . import exceptions
+from . import helpers
 from . import types
 
 
@@ -127,7 +128,10 @@ class Field(object):
     def __validate_required(self, value):
         """Validate value against required constraint.
         """
-        if self.required and value in (self.__type.null_values + ['', None]):
+        missing_values = self.descriptor.get('missingValues', [])
+        null_values = self.__type.null_values + missing_values + ['', None]
+        null_values = map(helpers.normalize_value, null_values)
+        if self.required and (helpers.normalize_value(value) in null_values):
             message = 'The field "%s" requires a value' % self.name
             raise exceptions.ConstraintError(message)
         return True

--- a/jsontableschema/field.py
+++ b/jsontableschema/field.py
@@ -112,6 +112,8 @@ class Field(object):
                     value = self.__type.cast(value, skip_constraints=True)
                 except exceptions.InvalidCastError:
                     return False
+                if value is None:
+                    return True
             validator = getattr(self, '_Field__validate_%s' % constraint)
             try:
                 validator(value)

--- a/jsontableschema/types/base.py
+++ b/jsontableschema/types/base.py
@@ -97,10 +97,11 @@ class JTSType(object):
 
             # Check required constraint
             if not skip_constraints:
+                missing_values = self.field.get('missingValues', [])
                 required = self.__constraints.get('required', False)
                 constraints.check_required(
                     self.__field_name, value, required,
-                    self.null_values+[None])
+                    self.null_values + missing_values + [None])
 
             return None
 
@@ -181,5 +182,7 @@ class JTSType(object):
             true if a null value
 
         """
-        null_values = map(helpers.normalize_value, self.null_values)
+        missing_values = self.field.get('missingValues', [])
+        null_values = self.null_values + missing_values
+        null_values = map(helpers.normalize_value, null_values)
         return helpers.normalize_value(value) in null_values

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -83,12 +83,39 @@ def test_test_value_not_supported_constraint():
     assert Field(DESCRIPTOR_MIN).test_value('', constraint='bad') == True
 
 
+# Tests [missingValues]
+
+def test_string_missingValues():
+    field = Field({
+        'name': 'name',
+        'type': 'string',
+        'missingValues': ['NA', 'N/A']
+    })
+    cast = field.cast_value
+    assert cast('') == ''
+    assert cast('NA') == None
+    assert cast('N/A') == None
+
+
+def test_number_missingValues():
+    field = Field({
+        'name': 'name',
+        'type': 'number',
+        'missingValues': ['NA', 'N/A']
+    })
+    cast = field.cast_value
+    assert cast('') == None
+    assert cast('NA') == None
+    assert cast('N/A') == None
+
+
 # Tests [constraints]
 
 def test_test_value_required():
     field = Field({
         'name': 'name',
         'type': 'string',
+        'missingValues': ['NA', 'N/A'],
         'constraints': {'required': True}
     })
     test = partial(field.test_value, constraint='required')
@@ -97,8 +124,10 @@ def test_test_value_required():
     assert test('none') == False
     assert test('nil') == False
     assert test('nan') == False
+    assert test('NA') == False
+    assert test('N/A') == False
     assert test('-') == False
-    assert test('') == False
+    assert test('') == True
     assert test(None) == False
 
 


### PR DESCRIPTION
- fixes #84

---

This makes this call valid for all rows except 2 and 3 (commented ones):
```bash
python -m goodtables.cli datapackage https://raw.githubusercontent.com/frictionlessdata/ADB-User-Study/master/datapackage.json
```